### PR TITLE
Prevent auto-scroll from resetting inactivity rotation

### DIFF
--- a/src/hooks/useInactivityRotation.ts
+++ b/src/hooks/useInactivityRotation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { isNonCareerAssociate } from "../utils/roleUtils";
 
@@ -19,6 +19,7 @@ export const useInactivityRotation = (
   const location = useLocation();
   const timeoutRef = useRef<NodeJS.Timeout>();
   const currentRouteIndexRef = useRef(0);
+  const suppressScrollActivityRef = useRef(false);
 
   // Define the rotation sequence for non-CA users
   const rotationSequence = [
@@ -50,6 +51,10 @@ export const useInactivityRotation = (
       }
     }
   }, [location]);
+
+  const setSuppressScrollActivity = useCallback((value: boolean) => {
+    suppressScrollActivityRef.current = value;
+  }, []);
 
   const resetInactivityTimer = () => {
     if (timeoutRef.current) {
@@ -93,7 +98,17 @@ export const useInactivityRotation = (
       "click",
     ];
 
-    const handleActivity = () => {
+    const handleActivity = (event: Event) => {
+      if (event.type === "scroll") {
+        if (suppressScrollActivityRef.current) {
+          return;
+        }
+
+        if (!event.isTrusted) {
+          return;
+        }
+      }
+
       resetInactivityTimer();
     };
 
@@ -130,6 +145,7 @@ export const useInactivityRotation = (
     resetTimer: resetInactivityTimer,
     currentRouteIndex: currentRouteIndexRef.current,
     rotationSequence,
+    setSuppressScrollActivity,
   };
 };
 

--- a/src/hooks/useLeaderboardAutoScroll.ts
+++ b/src/hooks/useLeaderboardAutoScroll.ts
@@ -6,6 +6,7 @@ interface LeaderboardAutoScrollOptions {
   inactivityTimeoutMs?: number;
   scrollSpeed?: number;
   activeTab?: string;
+  onAutoScrollStateChange?: (isAutoScrolling: boolean) => void;
 }
 
 /**
@@ -19,7 +20,8 @@ export const useLeaderboardAutoScroll = (
     enabled = true,
     inactivityTimeoutMs = 5000, // 5 seconds as specified
     scrollSpeed = 1, // pixels per frame
-    activeTab = "team"
+    activeTab = "team",
+    onAutoScrollStateChange,
   } = options;
 
   const timeoutRef = useRef<NodeJS.Timeout>();
@@ -58,6 +60,7 @@ export const useLeaderboardAutoScroll = (
     }
 
     isScrollingRef.current = true;
+    onAutoScrollStateChange?.(true);
     
     const animate = () => {
       if (!scrollContainerRef.current || !isScrollingRef.current) {
@@ -91,6 +94,7 @@ export const useLeaderboardAutoScroll = (
     if (animationRef.current) {
       cancelAnimationFrame(animationRef.current);
     }
+    onAutoScrollStateChange?.(false);
   };
 
   // Handle user activity to reset timer

--- a/src/pages/UnderConstruction.tsx
+++ b/src/pages/UnderConstruction.tsx
@@ -688,7 +688,7 @@ export const Leaderboard: React.FC = () => {
   }, [routeActiveTab, activeTab]);
 
   // Initialize inactivity rotation for non-CA users
-  useInactivityRotation({
+  const { setSuppressScrollActivity } = useInactivityRotation({
     enabled: !hasCareerAccess, // Only enable for non-CA users
     inactivityTimeoutMs: 30000, // 30 seconds
   });
@@ -699,6 +699,7 @@ export const Leaderboard: React.FC = () => {
     activeTab: activeTab, // Pass current active tab
     inactivityTimeoutMs: 5000, // 5 seconds as specified
     scrollSpeed: 1, // Smooth scroll speed
+    onAutoScrollStateChange: setSuppressScrollActivity,
   });
 
   const endpoint = `/leaderboard?data=${period}&type=${activeTab}`;


### PR DESCRIPTION
## Summary
- guard inactivity rotation listeners against programmatic scroll events
- expose a scroll suppression setter so the leaderboard auto-scroll can toggle it
- wire the leaderboard page to share auto-scroll state with the rotation hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacac799e0832eb5987a1480e3a2b8