### PR TITLE
Refine inactivity rotation to rely on timed steps

### DIFF
--- a/src/pages/UnderConstruction.tsx
+++ b/src/pages/UnderConstruction.tsx
@@ -688,7 +688,7 @@ export const Leaderboard: React.FC = () => {
   }, [routeActiveTab, activeTab]);
 
   // Initialize inactivity rotation for non-CA users
-  useInactivityRotation({
+  const { notifyIndividualViewComplete } = useInactivityRotation({
     enabled: !hasCareerAccess, // Only enable for non-CA users
     inactivityTimeoutMs: 30000, // 30 seconds
   });
@@ -699,6 +699,7 @@ export const Leaderboard: React.FC = () => {
     activeTab: activeTab, // Pass current active tab
     inactivityTimeoutMs: 5000, // 5 seconds as specified
     scrollSpeed: 1, // Smooth scroll speed
+    onAutoScrollComplete: notifyIndividualViewComplete,
   });
 
   const endpoint = `/leaderboard?data=${period}&type=${activeTab}`;


### PR DESCRIPTION
## Summary
- drive the kiosk rotation with fixed 30-second timers for Spaces and Team leaderboard views while waiting for the individual view to signal completion
- let the inactivity rotation hook expose an individual-view completion notifier and stop listening to auto-scroll events
- update the leaderboard auto-scroll hook to stop at the end of its pass and invoke the rotation notifier so it routes back to Spaces

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacac799e0832eb5987a1480e3a2b8