### PR TITLE
Guard inactivity timer from auto-scroll events

### DIFF
--- a/src/hooks/useInactivityRotation.ts
+++ b/src/hooks/useInactivityRotation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { isNonCareerAssociate } from "../utils/roleUtils";
 
@@ -19,21 +19,77 @@ export const useInactivityRotation = (
   const location = useLocation();
   const timeoutRef = useRef<NodeJS.Timeout>();
   const currentRouteIndexRef = useRef(0);
+  const suppressScrollActivityRef = useRef(false);
 
   // Define the rotation sequence for non-CA users
-  const rotationSequence = [
-    { path: "/spaces", displayName: "Spaces" },
-    {
-      path: "/leaderboard",
-      state: { activeTab: "team" },
-      displayName: "Leaderboard Team",
-    },
-    {
-      path: "/leaderboard",
-      state: { activeTab: "individual" },
-      displayName: "Leaderboard Individual",
-    },
-  ];
+  const rotationSequence = useMemo(
+    () => [
+      { path: "/spaces", displayName: "Spaces" },
+      {
+        path: "/leaderboard",
+        state: { activeTab: "team" },
+        displayName: "Leaderboard Team",
+      },
+      {
+        path: "/leaderboard",
+        state: { activeTab: "individual" },
+        displayName: "Leaderboard Individual",
+      },
+    ],
+    []
+  );
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = undefined;
+    }
+  }, []);
+
+  const advanceToNextRoute = useCallback(() => {
+    if (!enabled || !isNonCareerAssociate()) {
+      return;
+    }
+
+    currentRouteIndexRef.current =
+      (currentRouteIndexRef.current + 1) % rotationSequence.length;
+    const nextRoute = rotationSequence[currentRouteIndexRef.current];
+
+    if (nextRoute.state) {
+      navigate(nextRoute.path, { state: nextRoute.state });
+    } else {
+      navigate(nextRoute.path);
+    }
+  }, [enabled, navigate, rotationSequence]);
+
+  const scheduleForCurrentRoute = useCallback(() => {
+    clearTimer();
+
+    if (!enabled || !isNonCareerAssociate()) {
+      return;
+    }
+
+    const currentStep = rotationSequence[currentRouteIndexRef.current];
+    const isIndividualStep =
+      currentStep.path === "/leaderboard" &&
+      currentStep.state?.activeTab === "individual";
+
+    if (isIndividualStep) {
+      return; // Wait for the individual leaderboard scroll to complete
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      advanceToNextRoute();
+    }, inactivityTimeoutMs);
+  }, [advanceToNextRoute, clearTimer, enabled, inactivityTimeoutMs, rotationSequence]);
+
+  const resetInactivityTimer = useCallback(() => {
+    scheduleForCurrentRoute();
+  }, [scheduleForCurrentRoute]);
+
+  const setScrollActivitySuppressed = useCallback((value: boolean) => {
+    suppressScrollActivityRef.current = value;
+  }, []);
 
   // Update current route index when location changes
   useEffect(() => {
@@ -49,51 +105,35 @@ export const useInactivityRotation = (
         currentRouteIndexRef.current = 1; // default to team
       }
     }
-  }, [location]);
 
-  const resetInactivityTimer = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    // Only set timer for non-career associates and when enabled
-    if (!enabled || !isNonCareerAssociate()) {
-      return;
-    }
-
-    timeoutRef.current = setTimeout(() => {
-      // Move to next route in sequence
-      currentRouteIndexRef.current =
-        (currentRouteIndexRef.current + 1) % rotationSequence.length;
-      const nextRoute = rotationSequence[currentRouteIndexRef.current];
-
-      console.log(`Auto-rotating to: ${nextRoute.displayName}`);
-
-      if (nextRoute.state) {
-        navigate(nextRoute.path, { state: nextRoute.state });
-      } else {
-        navigate(nextRoute.path);
-      }
-    }, inactivityTimeoutMs);
-  };
+    resetInactivityTimer();
+  }, [location, resetInactivityTimer]);
 
   useEffect(() => {
     // Only attach listeners for non-career associates
     if (!enabled || !isNonCareerAssociate()) {
+      clearTimer();
       return;
     }
 
-    const events = [
+    const events: Array<keyof DocumentEventMap> = [
       "mousedown",
       "mousemove",
       "keypress",
       "keydown",
-      "scroll",
       "touchstart",
       "click",
+      "scroll",
     ];
 
-    const handleActivity = () => {
+    const handleActivity = (event: Event) => {
+      if (
+        event.type === "scroll" &&
+        (!event.isTrusted || suppressScrollActivityRef.current)
+      ) {
+        return;
+      }
+
       resetInactivityTimer();
     };
 
@@ -111,25 +151,39 @@ export const useInactivityRotation = (
         document.removeEventListener(event, handleActivity, true);
       });
 
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      clearTimer();
     };
-  }, [enabled, inactivityTimeoutMs]);
+  }, [clearTimer, enabled, resetInactivityTimer]);
+
+  const notifyIndividualViewComplete = useCallback(() => {
+    if (!enabled || !isNonCareerAssociate()) {
+      return;
+    }
+
+    const currentStep = rotationSequence[currentRouteIndexRef.current];
+    const isIndividualStep =
+      currentStep.path === "/leaderboard" &&
+      currentStep.state?.activeTab === "individual";
+
+    if (!isIndividualStep) {
+      return;
+    }
+
+    advanceToNextRoute();
+  }, [advanceToNextRoute, enabled, rotationSequence]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      clearTimer();
     };
-  }, []);
+  }, [clearTimer]);
 
   return {
     resetTimer: resetInactivityTimer,
     currentRouteIndex: currentRouteIndexRef.current,
     rotationSequence,
+    notifyIndividualViewComplete,
+    setScrollActivitySuppressed,
   };
 };
-

--- a/src/pages/UnderConstruction.tsx
+++ b/src/pages/UnderConstruction.tsx
@@ -688,10 +688,11 @@ export const Leaderboard: React.FC = () => {
   }, [routeActiveTab, activeTab]);
 
   // Initialize inactivity rotation for non-CA users
-  useInactivityRotation({
-    enabled: !hasCareerAccess, // Only enable for non-CA users
-    inactivityTimeoutMs: 30000, // 30 seconds
-  });
+  const { notifyIndividualViewComplete, setScrollActivitySuppressed } =
+    useInactivityRotation({
+      enabled: !hasCareerAccess, // Only enable for non-CA users
+      inactivityTimeoutMs: 30000, // 30 seconds
+    });
 
   // Initialize auto-scroll for leaderboard card (non-CA users, individual tab only)
   const { scrollContainerRef, handleScroll } = useLeaderboardAutoScroll({
@@ -699,6 +700,8 @@ export const Leaderboard: React.FC = () => {
     activeTab: activeTab, // Pass current active tab
     inactivityTimeoutMs: 5000, // 5 seconds as specified
     scrollSpeed: 1, // Smooth scroll speed
+    onAutoScrollComplete: notifyIndividualViewComplete,
+    onAutoScrollStateChange: setScrollActivitySuppressed,
   });
 
   const endpoint = `/leaderboard?data=${period}&type=${activeTab}`;


### PR DESCRIPTION
## Summary
- add a scroll suppression flag to the inactivity rotation hook so programmatic leaderboard scrolling no longer resets the timer
- let the leaderboard auto-scroll hook emit its running state and signal completion while keeping non-career associates in sync
- wire the leaderboard page to forward the auto-scroll state changes into the inactivity rotation hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacac799e0832eb5987a1480e3a2b8